### PR TITLE
fix for zero vector issue

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -46,7 +46,6 @@ LinearSolver(type::LinearSolverType) = LinearSolver(type, 500, 1e-8, 1e-6, false
 function rsolve(sol::LinearSolver, A, b)
     x = zeros(size(A, 2))
     rsolve!(x, sol, A, b)
-    println(x)
     return x
 end
 


### PR DESCRIPTION
Responds to:
https://github.com/dmaldona/RLinearAlgebra.jl/issues/3
(from the old repo)

Seems that the issue is due to Julia's scoping rules. I should, however, change projection to projection! in the future.