### PR TITLE
Testing Error Thresholds

### DIFF
--- a/test/linear_solver_routines/proc_vec_col_projection_portho.jl
+++ b/test/linear_solver_routines/proc_vec_col_projection_portho.jl
@@ -41,7 +41,7 @@ using Test, RLinearAlgebra, LinearAlgebra, Random
             RLinearAlgebra.rsubsolve!(rsub, z, (e, A, res), i)
         end
 
-        norm( A[:,2:6]'*(A * z - b)) < eps()*1e3 #Ajdust for condition number
+        norm( A[:,2:6]'*(A * z - b)) < eps()*1e4 #Ajdust for condition number
     end
 
     @test let
@@ -52,7 +52,7 @@ using Test, RLinearAlgebra, LinearAlgebra, Random
             RLinearAlgebra.rsubsolve!(rsub, z, (e, A, res), i)
         end
 
-        norm( A[:,4:8]'*(A * z - b)) < eps()*1e3 #Adjust for condition number
+        norm( A[:,4:8]'*(A * z - b)) < eps()*1e4 #Adjust for condition number
     end
 end
 

--- a/test/linear_solver_routines/proc_vec_col_projection_portho.jl
+++ b/test/linear_solver_routines/proc_vec_col_projection_portho.jl
@@ -41,7 +41,7 @@ using Test, RLinearAlgebra, LinearAlgebra, Random
             RLinearAlgebra.rsubsolve!(rsub, z, (e, A, res), i)
         end
 
-        norm( A[:,2:6]'*(A * z - b)) < 1e-13 #Ajdust for condition number
+        norm( A[:,2:6]'*(A * z - b)) < eps()*1e3 #Ajdust for condition number
     end
 
     @test let
@@ -52,7 +52,7 @@ using Test, RLinearAlgebra, LinearAlgebra, Random
             RLinearAlgebra.rsubsolve!(rsub, z, (e, A, res), i)
         end
 
-        norm( A[:,4:8]'*(A * z - b)) < 1e-13 #Adjust for condition number
+        norm( A[:,4:8]'*(A * z - b)) < eps()*1e3 #Adjust for condition number
     end
 end
 

--- a/test/linear_solver_routines/proc_vec_col_projection_std.jl
+++ b/test/linear_solver_routines/proc_vec_col_projection_std.jl
@@ -31,7 +31,7 @@ using Test, RLinearAlgebra, LinearAlgebra, Random
             # Update
             RLinearAlgebra.rsubsolve!(rsub, z, (e, A, dot(A * e, A * z - b)), i)
 
-            abs(dot(A[:,i], A * z - b)) < 1e-15
+            abs(dot(A[:,i], A * z - b)) < eps()*1e2
         end
     end
 end


### PR DESCRIPTION
The thresholds for the tests are hard-coded rather than using `eps()`. This caused problems during testing at

- https://github.com/numlinalg/RLinearAlgebra.jl/blob/d9e2d367b019cae24c8a542363ebeec6454ba9dc/test/linear_solver_routines/proc_vec_col_projection_std.jl#L34
- https://github.com/numlinalg/RLinearAlgebra.jl/blob/d9e2d367b019cae24c8a542363ebeec6454ba9dc/test/linear_solver_routines/proc_vec_col_projection_portho.jl#L44

The thresholds have been changed now based on `eps()` and a multiplicative factor. This multiplicative factor has been determined heuristically rather than through a careful numerical analysis.