### PR TITLE
Corrected distance calculation

### DIFF
--- a/src/linear_samplers/vec_row_max_distance.jl
+++ b/src/linear_samplers/vec_row_max_distance.jl
@@ -20,7 +20,9 @@ function sample(
     x::AbstractVector,
     iter::Int64
 )
-    eqn_indx = argmax(abs.(A * x - b) ./ sum(A.^2, dims=2)[:])
+
+    # Largest Square Distance 
+    eqn_indx = argmax(abs2.(A * x - b) ./ sum(A.^2, dims=2)[:])
 
     return A[eqn_indx,:], b[eqn_indx]
 end


### PR DESCRIPTION
The distance between a point, $z$, and a hyperplane $\lbrace y : a^\intercal y + b = 0 \rbrace$ is
$$\frac{|a^\intercal z + b|}{\Vert a \Vert_2}.$$

The previous code had the denominator squared, and then computed the index that maximized the distance between all residuals. This code squares the numerator so that we are computing the distance squared and then choosing the equation that maximizes this value. 