### PR TITLE
Updates to GitHub workflows; Adds Code Coverage to v0.2

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - master
+      - main
+      - v0.2-main
     tags: '*'
   pull_request:
+    branches:
+      - master
+      - main
+      - v0.2-main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -1,5 +1,21 @@
-name: Runtests
-on: [pull_request]
+name: Tests
+on:
+  push:
+    branches:
+      - master
+      - main
+      - v0.2-main
+    tags: '*'
+  pull_request:
+    branches:
+      - master
+      - main
+      - v0.2-main
+
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -9,9 +25,18 @@ jobs:
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: numlinalg/RLinearAlgebra.jl
+          fail_ci_if_error: false

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # RLinearAlgebra
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://numlinalg.github.io/RLinearAlgebra.jl/dev)
 [![Runtests](https://github.com/numlinalg/RLinearAlgebra.jl/actions/workflows/Runtests.yml/badge.svg)](https://github.com/numlinalg/RLinearAlgebra.jl/actions/workflows/Runtests.yml)
+[![codecov](https://codecov.io/github/numlinalg/RLinearAlgebra.jl/graph/badge.svg?token=GI7YUNM4YO)](https://codecov.io/github/numlinalg/RLinearAlgebra.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
 RLinearAlgebra is a Julia package that implements standard Randomized Linear Algebra algorithms and provides means for performance comparison.


### PR DESCRIPTION
This PR modifies several GitHub workflows as follows.

# Documentation Workflow

The documentation workflow will now be run every time there is a push or pull request to branches: `main`, `master` and `v0.2-main`. Note, `main` does not exist but it should replace `master` to be aligned with contemporary Github naming practices. Before, only a push to master and any PR would trigger this workflow.

# Testing Workflow

The testing workflow will now be run every time there is a push or pull request to branches: `main`, `master` and `v0.2-main`. Note, `main` does not exist but it should replace `master` to be aligned with contemporary Github naming practices. Before, only a push to master and any PR would trigger this workflow.

Code coverage actions are added to the testing workflow and the results are then shared with codecov.io, which will visualize results of the code coverage.

Note, an additional action is now part of the checking process called `codecov/patch`. This indicates whether the results of testing and codecov.io are shared to codecov.io. One can view this for a particular branch by going to https://app.codecov.io/github/numlinalg/RLinearAlgebra.jl and navigating to the branch that is the basis for the PR. 

# Readme

The readme is augmented with the code coverage badge. 
