### PR TITLE
Improving code coverage for Compressors.jl

### DIFF
--- a/src/Compressors.jl
+++ b/src/Compressors.jl
@@ -117,13 +117,12 @@ $(comp_method_description[:complete_compressor])
 - $(comp_error_list[:complete_compressor])
 """
 function complete_compressor(compressor::Compressor, A::AbstractMatrix)
-    throw(
+    return throw(
         ArgumentError(
             "No `complete_compressor` method exists for compressor of type \
             $(typeof(compressor)) and matrix of type $(typeof(A))."
         )
     )
-    return nothing
 end
 
 """
@@ -197,13 +196,12 @@ $(comp_method_description[:update_compressor])
 - $(comp_error_list[:update_compressor])
 """
 function update_compressor!(S::CompressorRecipe)
-    throw(
+    return throw(
         ArgumentError(
             "No method `update_compressor` exists for compressor recipe of type \
             $(typeof(S))."
         )
     )
-    return nothing
 end
 
 """
@@ -448,13 +446,12 @@ function mul!(
     alpha::Number, 
     beta::Number
 )
-    throw(
+    return throw(
         ArgumentError(
             "No method `mul!` defined for ($(typeof(C)), $(typeof(S)), \
             $(typeof(A)), $(typeof(alpha)), $(typeof(beta)))."
         )
     )
-    return nothing
 end
 
 # alpha*A*S + beta*C -> C
@@ -465,13 +462,12 @@ function mul!(
     alpha::Number, 
     beta::Number
 )
-    throw(
+    return throw(
         ArgumentError(
             "No method `mul!` defined for ($(typeof(C)), $(typeof(A)), \
             $(typeof(S)), $(typeof(alpha)), $(typeof(beta)))."
         )
     )
-    return nothing
 end
 
 # alpha * S'*A + beta*C -> C (equivalently, alpha * A' * S + beta + C' -> C')

--- a/test/Compressors/compressor_abstract_adjoint.jl
+++ b/test/Compressors/compressor_abstract_adjoint.jl
@@ -1,0 +1,49 @@
+module compressor_abstract_adjoint
+using Test, RLinearAlgebra
+import LinearAlgebra: mul!
+using ..FieldTest
+using ..ApproxTol
+
+#####################
+# Testing Parameters
+##################### 
+mutable struct TestCompressorRecipe <: CompressorRecipe
+    n_rows::Int64
+    n_cols::Int64
+end
+s_rows = 3
+s_cols = 4
+
+@testset "Compressor Recipe Adjoints" begin
+    # Adjoint 
+    let compress = TestCompressorRecipe(s_rows, s_cols)
+        compress_adjoint = adjoint(compress) 
+        @test typeof(compress_adjoint) == CompressorAdjoint{TestCompressorRecipe}
+    end
+
+    # Adjoint of Adjoint 
+    let compress = TestCompressorRecipe(s_rows, s_cols),
+        compress_adjoint = adjoint(compress)
+
+        compress_adjoint_adjoint = adjoint(compress_adjoint)
+        @test compress_adjoint_adjoint == compress 
+        @test typeof(compress_adjoint_adjoint) == TestCompressorRecipe
+    end
+
+    # Transpose 
+    let compress = TestCompressorRecipe(s_rows, s_cols)
+        compress_transpose = transpose(compress) 
+        @test typeof(compress_transpose) == CompressorAdjoint{TestCompressorRecipe}
+    end
+
+    # Transpose of Transpose
+    let compress = TestCompressorRecipe(s_rows, s_cols),
+        compress_transpose = transpose(compress)
+
+        compressor_transpose_transpose = transpose(compress_transpose)
+        @test compressor_transpose_transpose == compress
+        @test typeof(compressor_transpose_transpose) == TestCompressorRecipe
+    end
+end
+
+end

--- a/test/Compressors/compressor_abstract_update.jl
+++ b/test/Compressors/compressor_abstract_update.jl
@@ -1,0 +1,85 @@
+module compressor_abstract_update 
+using Test, RLinearAlgebra
+import RLinearAlgebra: update_compressor! 
+import LinearAlgebra: mul!
+
+#####################
+# Testing Parameters
+##################### 
+mutable struct TestCompressorRecipe <: CompressorRecipe
+    n_rows::Int64
+    n_cols::Int64
+    status::Bool
+end
+
+function update_compressor!(compressor::TestCompressorRecipe) 
+    compressor.status = true
+    return true 
+end
+
+@testset "Compressor Recipe Update" begin
+
+    # Check Single Argument Update 
+    let compressor = TestCompressorRecipe(3, 4, false)
+        # Check initial status 
+        @test compressor.status == false
+
+        # Update compressor 
+        val = update_compressor!(compressor)
+
+        # Check updated status 
+        @test compressor.status == true
+        @test val == true 
+    end
+
+    # Check Two Argument Update 
+    let compressor = TestCompressorRecipe(3, 4, false),
+        A = randn(5, 6)
+
+        # Check initial status 
+        @test compressor.status == false
+
+        # Update compressor 
+        val = update_compressor!(compressor, A)
+
+        # Check updated status 
+        @test compressor.status == true
+        @test isnothing(val)
+    end
+
+    # Check Three Argument Update 
+    let compressor = TestCompressorRecipe(3, 4, false),
+        A = randn(5, 6),
+        b = randn(7)
+
+        # Check initial status 
+        @test compressor.status == false
+
+        # Update compressor 
+        val = update_compressor!(compressor, A, b)
+
+        # Check updated status 
+        @test compressor.status == true
+        @test isnothing(val)
+    end
+
+    # Check Four Argument Update 
+    let compressor = TestCompressorRecipe(3, 4, false),
+        A = randn(5, 6),
+        b = randn(7),
+        x = randn(8)
+
+        # Check initial status 
+        @test compressor.status == false
+
+        # Update compressor 
+        val = update_compressor!(compressor, x, A, b)
+
+        # Check updated status 
+        @test compressor.status == true
+        @test isnothing(val)
+    end
+
+end
+end
+


### PR DESCRIPTION
This PR addresses missing code coverage for Compressors.jl

1. Modifying functions that `throw` an error and return `nothing` by returning the `throw(...)`

2. Adding tests for compressor adjoints (abstractly)

3. Adding tests for updating compressors (abstractly)