### PR TITLE
Add Throws documentation to skeleton functions

### DIFF
--- a/docs/src/api/sub_solvers.md
+++ b/docs/src/api/sub_solvers.md
@@ -26,4 +26,6 @@ QRSolverRecipe
 complete_sub_solver
 
 update_sub_solver!
+
+ldiv!
 ```

--- a/src/Approximators.jl
+++ b/src/Approximators.jl
@@ -97,10 +97,14 @@ approx_method_description = Dict{Symbol,String}(
 )
 
 approx_error_list = Dict{Symbol,String}(
-    :complete_approximator => "`ArgumentError` if no method for completing the approximator exists for the given approximator type.",
-    :rapproximate => "`ArgumentError` if no method for computing the approximation exists for the given approximator type.",
-    :complete_approximator_error => "`ArgumentError` if no method for completing the approximator error exists for the given error type.",
-    :compute_approximator_error => "`ArgumentError` if no method for computing the approximator error exists for the given error type."
+    :complete_approximator => "`ArgumentError` if no method for completing the \
+    approximator exists for the given approximator type.",
+    :rapproximate => "`ArgumentError` if no method for computing the approximation \
+    exists for the given approximator type.",
+    :complete_approximator_error => "`ArgumentError` if no method for completing the \
+    approximator error exists for the given error type.",
+    :compute_approximator_error => "`ArgumentError` if no method for computing the \
+    approximator error exists for the given error type."
 )
 
 ###################################

--- a/src/Approximators.jl
+++ b/src/Approximators.jl
@@ -96,6 +96,13 @@ approx_method_description = Dict{Symbol,String}(
     `ApproximatorRecipe` for a matrix `A`.",
 )
 
+approx_error_list = Dict{Symbol,String}(
+    :complete_approximator => "`ArgumentError` if no method for completing the approximator exists for the given approximator type.",
+    :rapproximate => "`ArgumentError` if no method for computing the approximation exists for the given approximator type.",
+    :complete_approximator_error => "`ArgumentError` if no method for completing the approximator error exists for the given error type.",
+    :compute_approximator_error => "`ArgumentError` if no method for computing the approximator error exists for the given error type."
+)
+
 ###################################
 # Approximator Adjoint 
 ###################################
@@ -155,6 +162,9 @@ $(approx_method_description[:complete_approximator])
 
 # Outputs
 - $(approx_output_list[:approximator_recipe])
+
+# Throws
+- $(approx_error_list[:complete_approximator])
 """
 function complete_approximator(approximator::Approximator, A::AbstractMatrix)
     return throw(
@@ -180,6 +190,9 @@ $(approx_method_description[:rapproximate])
 
 # Outputs
 - $(approx_output_list[:approximator_recipe])
+
+# Throws
+- $(approx_error_list[:rapproximate])
 """
 function rapproximate!(approximator::ApproximatorRecipe, A::AbstractMatrix)
     return throw(
@@ -228,6 +241,9 @@ $(approx_method_description[:complete_approximator_error])
 
 # Outputs
 - $(approx_output_list[:approximator_error_recipe])
+
+# Throws
+- $(approx_error_list[:complete_approximator_error])
 """
 function complete_approximator_error(
     error::ApproximatorError, 
@@ -261,6 +277,9 @@ $(approx_method_description[:compute_approximator_error])
 
 # Outputs
 - Returns the `error::Float64` 
+
+# Throws
+- $(approx_error_list[:compute_approximator_error])
 """
 function compute_approximator_error!(
     error::ApproximatorErrorRecipe, 

--- a/src/Approximators/Selectors.jl
+++ b/src/Approximators/Selectors.jl
@@ -42,9 +42,12 @@ select_method_description = Dict{Symbol,String}(
 )
 
 select_error_list = Dict{Symbol,String}(
-    :complete_selector => "`ArgumentError` if no method for completing the selector exists for the given selector type.",
-    :update_selector => "`ArgumentError` if no method for updating the selector exists for the given selector type.",
-    :select_indices => "`ArgumentError` if no method for selecting indices exists for the given selector type."
+    :complete_selector => "`ArgumentError` if no method for completing the selector exists \
+    for the given selector type.",
+    :update_selector => "`ArgumentError` if no method for updating the selector exists for \
+    the given selector type.",
+    :select_indices => "`ArgumentError` if no method for selecting indices exists for the \
+    given selector type."
 )
 ##################################
 # Complete Selector Interface

--- a/src/Approximators/Selectors.jl
+++ b/src/Approximators/Selectors.jl
@@ -40,6 +40,12 @@ select_method_description = Dict{Symbol,String}(
     `SelectorRecipe`. It updates the vector `idx` in place with `n_idx` new indices starting
     at index `start_idx`."
 )
+
+select_error_list = Dict{Symbol,String}(
+    :complete_selector => "`ArgumentError` if no method for completing the selector exists for the given selector type.",
+    :update_selector => "`ArgumentError` if no method for updating the selector exists for the given selector type.",
+    :select_indices => "`ArgumentError` if no method for selecting indices exists for the given selector type."
+)
 ##################################
 # Complete Selector Interface
 ##################################
@@ -54,6 +60,9 @@ $(select_method_description[:complete_selector])
 
 # Outputs
 - $(select_output_list[:selector_recipe])
+
+# Throws
+- $(select_error_list[:complete_selector])
 """
 function complete_selector(selector::Selector, A::AbstractMatrix)
     return throw(
@@ -77,6 +86,9 @@ $(select_method_description[:update_selector])
 
 # Outputs
 - $(select_output_list[:selector_recipe])
+
+# Throws
+- $(select_error_list[:update_selector])
 """
 function update_selector!(selector::SelectorRecipe)
     return throw(
@@ -126,6 +138,9 @@ $(select_method_description[:select_indices])
 
 # Outputs
 -  Returns `nothing`
+
+# Throws
+- $(select_error_list[:select_indices])
 """
 function select_indices!(
     idx::AbstractVector,

--- a/src/Compressors/Distributions.jl
+++ b/src/Compressors/Distributions.jl
@@ -32,6 +32,12 @@ distribution_method_description = Dict{Symbol,String}(
     arguments.",
     :sample_distribution! => "A function that in place updates the `x` by given `DistributionRecipe` info.",
 )
+
+distribution_error_list = Dict{Symbol,String}(
+    :complete_distribution => "`ArgumentError` if no method for completing the distribution exists for the given distribution type.",
+    :update_distribution! => "`ArgumentError` if no method for updating the distribution exists for the given distribution type.",
+    :sample_distribution! => "`ArgumentError` if no method for sampling from the distribution exists for the given distribution type."
+)
 """
     complete_distribution(distribution::Distribution, A::AbstractMatrix)
 
@@ -43,6 +49,9 @@ $(distribution_method_description[:complete_distribution])
 
 # Outputs
 - $(distribution_output_list[:distribution_recipe])
+
+# Throws
+- $(distribution_error_list[:complete_distribution])
 """
 function complete_distribution(distribution::Distribution, A::AbstractMatrix)
     return throw(ArgumentError("No `complete_distribution` method defined for a distribution of type \
@@ -68,6 +77,9 @@ $(distribution_method_description[:update_distribution!])
 
 # Outputs
 - Modifies the `DistributionRecipe` in place and returns nothing.
+
+# Throws
+- $(distribution_error_list[:update_distribution!])
 """
 function update_distribution!(distribution::DistributionRecipe, A::AbstractMatrix)
     return throw(ArgumentError("No `update_distribution!` method defined for a distribution of type \
@@ -94,6 +106,9 @@ $(distribution_method_description[:sample_distribution!])
 # Outputs
 - Modifies the `x` in place by sampling that follows the weights and replacement given by 
 'DistributionRecipe'.
+
+# Throws
+- $(distribution_error_list[:sample_distribution!])
 """
 function sample_distribution!(x::AbstractVector, distribution::DistributionRecipe)
     return throw(ArgumentError("No `sample_distribution!` method defined for a distribution of type \

--- a/src/Compressors/Distributions.jl
+++ b/src/Compressors/Distributions.jl
@@ -34,9 +34,12 @@ distribution_method_description = Dict{Symbol,String}(
 )
 
 distribution_error_list = Dict{Symbol,String}(
-    :complete_distribution => "`ArgumentError` if no method for completing the distribution exists for the given distribution type.",
-    :update_distribution! => "`ArgumentError` if no method for updating the distribution exists for the given distribution type.",
-    :sample_distribution! => "`ArgumentError` if no method for sampling from the distribution exists for the given distribution type."
+    :complete_distribution => "`ArgumentError` if no method for completing the \
+    distribution exists for the given distribution type.",
+    :update_distribution! => "`ArgumentError` if no method for updating the \
+    distribution exists for the given distribution type.",
+    :sample_distribution! => "`ArgumentError` if no method for sampling from the \
+    distribution exists for the given distribution type."
 )
 """
     complete_distribution(distribution::Distribution, A::AbstractMatrix)

--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -42,6 +42,11 @@ solver_method_description = Dict{Symbol,String}(
     :rsolve => "A function that solves a linear system given the arguments.",
 )
 
+solver_error_list = Dict{Symbol,String}(
+    :complete_solver => "`ArgumentError` if no method for completing the solver exists for the given solver type.",
+    :rsolve => "`ArgumentError` if no method for solving the linear system exists for the given solver type."
+)
+
 ###################################
 # Complete Solver
 ###################################
@@ -58,6 +63,9 @@ $(solver_method_description[:complete_solver])
 
 # Outputs
 - $(solver_output_list[:solver_recipe])
+
+# Throws
+- $(solver_error_list[:complete_solver])
 """
 function complete_solver(
     solver::Solver, 
@@ -94,6 +102,9 @@ $(solver_method_description[:rsolve])
 
 # Outputs
 - Returns `nothing`. Updates the `SolverRecipe` and `x` in place.
+
+# Throws
+- $(solver_error_list[:rsolve])
 """
 function rsolve!(
     solver::SolverRecipe, 

--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -43,8 +43,10 @@ solver_method_description = Dict{Symbol,String}(
 )
 
 solver_error_list = Dict{Symbol,String}(
-    :complete_solver => "`ArgumentError` if no method for completing the solver exists for the given solver type.",
-    :rsolve => "`ArgumentError` if no method for solving the linear system exists for the given solver type."
+    :complete_solver => "`ArgumentError` if no method for completing the solver \
+    exists for the given solver type.",
+    :rsolve => "`ArgumentError` if no method for solving the linear system exists \
+    for the given solver type."
 )
 
 ###################################

--- a/src/Solvers/ErrorMethods.jl
+++ b/src/Solvers/ErrorMethods.jl
@@ -42,6 +42,11 @@ solver_method_description = Dict{Symbol,String}(
     :compute_error => "A function that evaluates the error for a proposed solution 
     vector.",
 )
+
+solver_error_list = Dict{Symbol,String}(
+    :complete_error => "`ArgumentError` if no method for completing the solver error exists for the given error and solver types.",
+    :compute_error => "`ArgumentError` if no method for computing the error exists for the given error and solver types."
+)
 # Function skeletons
 
 """
@@ -62,6 +67,9 @@ $(solver_method_description[:complete_error])
 
 # Returns 
 - $(solver_output_list[:solver_error_recipe])
+
+# Throws
+- $(solver_error_list[:complete_error])
 """
 function complete_error(
     error::SolverError, 
@@ -98,6 +106,9 @@ $(solver_method_description[:compute_error])
 
 # Returns 
 -  Returns `nothing`
+
+# Throws
+- $(solver_error_list[:compute_error])
 """
 function compute_error(
     error::SolverErrorRecipe,

--- a/src/Solvers/ErrorMethods.jl
+++ b/src/Solvers/ErrorMethods.jl
@@ -44,8 +44,10 @@ solver_method_description = Dict{Symbol,String}(
 )
 
 solver_error_list = Dict{Symbol,String}(
-    :complete_error => "`ArgumentError` if no method for completing the solver error exists for the given error and solver types.",
-    :compute_error => "`ArgumentError` if no method for computing the error exists for the given error and solver types."
+    :complete_error => "`ArgumentError` if no method for completing the solver \
+    error exists for the given error and solver types.",
+    :compute_error => "`ArgumentError` if no method for computing the error exists \
+    for the given error and solver types."
 )
 # Function skeletons
 

--- a/src/Solvers/Loggers.jl
+++ b/src/Solvers/Loggers.jl
@@ -35,6 +35,15 @@ logger_method_description = Dict{Symbol,String}(
     :reset_logger => "A function that resets the `LoggerRecipe` in place.", 
 )
 
+logger_error_list = Dict{Symbol, String}(
+    :complete_logger => "`ArgumentError` if no method for completing the logger exists 
+    for the given logger type.",
+    :update_logger => "`ArgumentError` if no method for updating the logger exists 
+    for the given logger type.",
+    :reset_logger => "`ArgumentError` if no method for resetting the logger exists 
+    for the given logger type."
+)
+
 """
     complete_logger(logger::Logger)
 
@@ -45,6 +54,9 @@ $(logger_method_description[:complete_logger])
 
 ### Returns 
 - $(logger_output_list[:logger_recipe])
+
+### Throws
+- $(logger_error_list[:complete_logger])
 """
 function complete_logger(logger::Logger)
     throw(ArgumentError("No `complete_logger` method defined for logger of type \
@@ -64,6 +76,9 @@ $(logger_method_description[:update_logger])
 
 ### Returns 
 - Performs an inplace update to the `LoggerRecipe` and returns nothing.
+
+### Throws
+- $(logger_error_list[:update_logger])
 """
 function update_logger!(logger::LoggerRecipe, err::Real, iteration::Int64)
     throw(ArgumentError("No `update_logger!` method defined for a logger of type \
@@ -82,6 +97,9 @@ $(logger_method_description[:reset_logger])
 
 ### Returns 
 - Performs an inplace update to the `LoggerRecipe` and returns nothing.
+
+### Throws
+- $(logger_error_list[:reset_logger])
 """
 function reset_logger!(logger::LoggerRecipe)
     throw(ArgumentError("No `reset_logger!` method defined for a logger of type \

--- a/src/Solvers/Loggers.jl
+++ b/src/Solvers/Loggers.jl
@@ -36,11 +36,11 @@ logger_method_description = Dict{Symbol,String}(
 )
 
 logger_error_list = Dict{Symbol, String}(
-    :complete_logger => "`ArgumentError` if no method for completing the logger exists 
+    :complete_logger => "`ArgumentError` if no method for completing the logger exists \
     for the given logger type.",
-    :update_logger => "`ArgumentError` if no method for updating the logger exists 
+    :update_logger => "`ArgumentError` if no method for updating the logger exists \
     for the given logger type.",
-    :reset_logger => "`ArgumentError` if no method for resetting the logger exists 
+    :reset_logger => "`ArgumentError` if no method for resetting the logger exists \
     for the given logger type."
 )
 

--- a/src/Solvers/SubSolvers.jl
+++ b/src/Solvers/SubSolvers.jl
@@ -32,14 +32,17 @@ sub_solver_method_description = Dict{Symbol,String}(
     arguments.",
     :update_sub_solver => "A function that updates the `SubSolver` in place given 
     arguments.",
-    :ldiv => "A function that solves a linear system using the `SubSolverRecipe` and stores 
-    the result in `x`.",
+    :ldiv => "An extension of `LinearAlgebra.ldiv!` that solves a linear system using the 
+    `SubSolverRecipe` and stores the result in `x`.",
 )
 
 sub_solver_error_list = Dict{Symbol,String}(
-    :complete_sub_solver => "`ArgumentError` if no method for completing the sub-solver exists for the given sub-solver type.",
-    :update_sub_solver => "`ArgumentError` if no method for updating the sub-solver exists for the given sub-solver type.",
-    :ldiv => "`ArgumentError` if no method for solving with the sub-solver exists for the given sub-solver type."
+    :complete_sub_solver => "`ArgumentError` if no method for completing the \
+    sub-solver exists for the given sub-solver type.",
+    :update_sub_solver => "`ArgumentError` if no method for updating the \
+    sub-solver exists for the given sub-solver type.",
+    :ldiv => "`ArgumentError` if no method for solving with the sub-solver \
+    exists for the given sub-solver type."
 )
 
 """
@@ -121,7 +124,8 @@ $(sub_solver_method_description[:ldiv])
 - `b::AbstractVector`, the right-hand side vector.
 
 # Returns
-- Modifies `x` in place to contain the solution and returns `x`.
+- Writes the solution to `solver` applied to the constant vector `b` into `x` and \
+returns `x`.
 
 # Throws
 - $(sub_solver_error_list[:ldiv])

--- a/src/Solvers/SubSolvers.jl
+++ b/src/Solvers/SubSolvers.jl
@@ -32,7 +32,16 @@ sub_solver_method_description = Dict{Symbol,String}(
     arguments.",
     :update_sub_solver => "A function that updates the `SubSolver` in place given 
     arguments.",
+    :ldiv => "A function that solves a linear system using the `SubSolverRecipe` and stores 
+    the result in `x`.",
 )
+
+sub_solver_error_list = Dict{Symbol,String}(
+    :complete_sub_solver => "`ArgumentError` if no method for completing the sub-solver exists for the given sub-solver type.",
+    :update_sub_solver => "`ArgumentError` if no method for updating the sub-solver exists for the given sub-solver type.",
+    :ldiv => "`ArgumentError` if no method for solving with the sub-solver exists for the given sub-solver type."
+)
+
 """
     complete_sub_solver(solver::SubSolver, A::AbstractArray)
 
@@ -44,6 +53,9 @@ $(sub_solver_method_description[:complete_sub_solver])
 
 # Returns 
 - $(sub_solver_output_list[:sub_solver_recipe])
+
+# Throws
+- $(sub_solver_error_list[:complete_sub_solver])
 """
 function complete_sub_solver(solver::SubSolver, A::AbstractArray)
     return throw(
@@ -66,6 +78,9 @@ $(sub_solver_method_description[:complete_sub_solver])
 
 # Returns 
 - $(sub_solver_output_list[:sub_solver_recipe])
+
+# Throws
+- $(sub_solver_error_list[:complete_sub_solver])
 """
 function complete_sub_solver(solver::SubSolver, A::AbstractArray, b::AbstractArray)
     complete_sub_solver(solver, A)
@@ -82,6 +97,9 @@ $(sub_solver_method_description[:update_sub_solver])
 
 # Returns
 - Modifies the `SubSolverRecipe` in place given the arguments.and returns nothing.
+
+# Throws
+- $(sub_solver_error_list[:update_sub_solver])
 """
 function update_sub_solver!(solver::SubSolverRecipe, A::AbstractArray)
     return  throw(
@@ -92,6 +110,22 @@ function update_sub_solver!(solver::SubSolverRecipe, A::AbstractArray)
     )
 end
 
+"""
+    ldiv!(x::AbstractVector, solver::SubSolverRecipe, b::AbstractVector)
+
+$(sub_solver_method_description[:ldiv])
+
+# Arguments
+- `x::AbstractVector`, the output vector to store the solution.
+- $(sub_solver_arg_list[:sub_solver_recipe])
+- `b::AbstractVector`, the right-hand side vector.
+
+# Returns
+- Modifies `x` in place to contain the solution and returns `x`.
+
+# Throws
+- $(sub_solver_error_list[:ldiv])
+"""
 function ldiv!(x::AbstractVector, solver::SubSolverRecipe, b::AbstractVector)
     return throw(
         ArgumentError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be sure to request review from @vp314, @dmaldona, and/or @nathanielpritchard -->

## Description
Adds `# Throws` documentation sections to skeleton functions across all interface modules.
<!--- Describe your changes in detail and include references -->
Fixes #133  <!--- If there is an issue being resolved, please indicate it here. Otherwise delete this line. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #133 requested documentation for throw statements in all skeleton functions across Compressors, Approximators, Solvers, SubSolvers, Loggers, and Selectors modules. These functions throw ArgumentError when called on the abstract interface types, but this behavior was not documented in the docstrings.

## How has this been tested
<!--- Please describe the manual steps a reviewer can take to verify your changes. -->
<!--- This is critical for ensuring the change works as expected. -->
Verified in Julia help system, and confirmed existing tests still pass.

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [x] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [ ] Fix <!--- Non-breaking change which addresses an issue -->
- [ ] Performance <!--- A code change that improves performance -->
- [ ] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [ ] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [ ] My code follows the code style of this project.
- [ ] I have updated all package dependencies (if any).
- [ ] I have included all relevant files to realize the functionality of the PR. 
- [ ] I have exported relevant functionality (if any).

**API Documentation**
- [x] For every exported function (if any), I have included a detailed docstring.
- [x] I have checked the spelling and grammar of all docstring updates through an external tool.
- [x] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [x] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [ ] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [ ] I have checked the spelling and grammar of all manual updates through an external tool.
- [ ] Any code included in the docstring is tested using doc tests to ensure consistency.
- [ ] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [ ] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [x] All new and existing tests passed.
- [ ] I have achieved sufficient code coverage.

