### PR TITLE
Adding Claude to support coding

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RandLinearAlgebra.jl is a Julia package implementing randomized linear algebra algorithms for:
+- Low-rank matrix approximations (Randomized SVD, Range Finder)
+- Solving linear systems (Kaczmarz, Column Projection, IHS solvers)
+- Matrix compression techniques (Gaussian, FJLT, SRHT, CountSketch, SparseSign, Sampling)
+
+**Documentation:** https://numlinalg.github.io/RandLinearAlgebra.jl/dev
+
+## Build and Test Commands
+
+```bash
+# Run all tests (standard Julia Pkg approach)
+julia --project -e 'using Pkg; Pkg.test()'
+
+# Build documentation locally
+julia --project=docs/ docs/make.jl
+```
+
+## Code Style
+
+Uses [BlueStyle](https://github.com/invenia/BlueStyle) formatting. Configuration in `.JuliaFormatter.toml`:
+- `style = "blue"`
+- `format_markdown = true`
+- `format_docstrings = false`
+
+## Architecture
+
+The library uses a **Recipe Pattern** with two abstraction levels:
+
+1. **Technique Types** (user-facing): Hold algorithm parameters only
+   - `Compressor`, `Solver`, `Approximator`, `Logger`, `SolverError`, `SubSolver`
+
+2. **Recipe Types** (internal): Include pre-allocated memory for computation
+   - `CompressorRecipe`, `SolverRecipe`, `ApproximatorRecipe`, etc.
+
+**Workflow:** `complete_*()` initializes a Recipe from a Technique → main functions (`rsolve!`, `rapproximate!`, `mul!`) execute
+
+### Key Components
+
+**Compressors** (`src/Compressors/`): 7 compression methods - CountSketch, FJLT, Gaussian, Identity, Sampling, SparseSign, SRHT. Support left/right multiplication via `Cardinality` types.
+
+**Solvers** (`src/Solvers/`): 3 iterative solvers - Kaczmarz (row projection), ColumnProjection (column subspace), IHS (Iterative Hessian Sketching). Supporting infrastructure includes Loggers, ErrorMethods, and SubSolvers.
+
+**Approximators** (`src/Approximators/`): RangeFinder and RandSVD for low-rank approximation. Selectors (LUPP, QRCP) for pivot selection.
+
+### Module Structure
+
+```
+src/RandLinearAlgebra.jl  # Main module, exports
+src/Compressors.jl        # Compressor abstractions
+src/Solvers.jl            # Solver abstractions
+src/Approximators.jl      # Approximator abstractions
+src/*/                    # Implementations in subdirectories
+```
+
+## Dependencies
+
+Runtime: LinearAlgebra, Random, SparseArrays, StatsBase (all in Project.toml)
+
+## PR Guidelines
+
+See `.github/pull_request_template.md` for checklist. Key requirements:
+- Detailed docstrings for exported functions
+- Unit tests with sufficient coverage
+- BlueStyle code formatting
+- Local doc compilation to verify changes
+
+## Docstring Conventions
+
+### Section Headers
+Use single `#` for top-level docstring sections:
+- `# Arguments` - function parameters
+- `# Returns` - return values (not "Outputs")
+- `# Throws` - exceptions that may be raised
+- `# Fields` - struct fields
+- `# Constructor` - constructor documentation
+- `# Mathematical Description` - algorithm explanation
+
+### Nested Sections
+Use `##` for subsections within constructors:
+- `## Keywords` - keyword arguments
+- `## Returns` - constructor return value
+
+### Reusable Docstring Components
+Use Dict interpolation for consistent argument/output descriptions:
+```julia
+arg_list = Dict{Symbol,String}(
+    :A => "`A::AbstractMatrix`, a coefficient matrix.",
+    :b => "`b::AbstractVector`, a constant vector.",
+)
+
+"""
+    my_function(A, b)
+
+# Arguments
+- $(arg_list[:A])
+- $(arg_list[:b])
+"""
+```
+
+### Admonitions
+Use standard Documenter.jl admonition syntax:
+```julia
+!!! note
+    Important information here.
+
+!!! info
+    Additional context here.
+```
+
+### Citations
+Use Documenter.jl citation syntax: `[author_year](@cite)`

--- a/src/Approximators.jl
+++ b/src/Approximators.jl
@@ -117,7 +117,7 @@ A structure for the adjoint of an `ApproximatorRecipe`.
 
 # Fields
 
-  - `Parent::ApproximatorRecipe`, the approximator that we compute the adjoint of.
+  - `parent::ApproximatorRecipe`, the approximator that we compute the adjoint of.
 """
 struct ApproximatorAdjoint{S<:ApproximatorRecipe} <: ApproximatorRecipe
     parent::S
@@ -164,7 +164,7 @@ $(approx_method_description[:complete_approximator])
 - $(approx_arg_list[:approximator])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(approx_output_list[:approximator_recipe])
 
 # Throws
@@ -192,7 +192,7 @@ $(approx_method_description[:rapproximate])
 - $(approx_arg_list[:approximator_recipe])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(approx_output_list[:approximator_recipe])
 
 # Throws
@@ -216,7 +216,7 @@ $(approx_method_description[:rapproximate])
 - $(approx_arg_list[:approximator])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(approx_output_list[:approximator_recipe])
 """
 function rapproximate(approximator::Approximator, A::AbstractMatrix)
@@ -243,7 +243,7 @@ $(approx_method_description[:complete_approximator_error])
 - $(approx_arg_list[:approximator_recipe])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(approx_output_list[:approximator_error_recipe])
 
 # Throws
@@ -279,7 +279,7 @@ $(approx_method_description[:compute_approximator_error])
 - $(approx_arg_list[:approximator_recipe])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - Returns the `error::Float64` 
 
 # Throws
@@ -313,7 +313,7 @@ $(approx_method_description[:compute_approximator_error])
 - $(approx_arg_list[:approximator_recipe])
 - $(approx_arg_list[:A]) 
 
-# Outputs
+# Returns
 - Returns the `error::Float64` 
 """
 function compute_approximator_error(

--- a/src/Approximators/Selectors.jl
+++ b/src/Approximators/Selectors.jl
@@ -61,7 +61,7 @@ $(select_method_description[:complete_selector])
 - $(select_arg_list[:selector])
 - $(select_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(select_output_list[:selector_recipe])
 
 # Throws
@@ -87,7 +87,7 @@ $(select_method_description[:update_selector])
 # Arguments
 - $(select_arg_list[:selector_recipe])
 
-# Outputs
+# Returns
 - $(select_output_list[:selector_recipe])
 
 # Throws
@@ -111,7 +111,7 @@ $(select_method_description[:update_selector])
 - $(select_arg_list[:selector_recipe])
 - $(select_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(select_output_list[:selector_recipe])
 """
 function update_selector!(selector::SelectorRecipe, A::AbstractMatrix)
@@ -139,7 +139,7 @@ $(select_method_description[:select_indices])
 - $(select_arg_list[:n_idx])
 - $(select_arg_list[:start_idx])
 
-# Outputs
+# Returns
 -  Returns `nothing`
 
 # Throws

--- a/src/Compressors.jl
+++ b/src/Compressors.jl
@@ -89,7 +89,7 @@ comp_error_list = Dict{Symbol, String}(
 A structure for the adjoint of a compression recipe.
 
 # Fields
-- `Parent::CompressorRecipe`, the CompressorRecipe the adjoint is being applied to.
+- `parent::CompressorRecipe`, the CompressorRecipe the adjoint is being applied to.
 """
 struct CompressorAdjoint{S<:CompressorRecipe}
     parent::S

--- a/src/Compressors/Distributions.jl
+++ b/src/Compressors/Distributions.jl
@@ -50,7 +50,7 @@ $(distribution_method_description[:complete_distribution])
 - $(distribution_arg_list[:distribution])
 - $(distribution_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(distribution_output_list[:distribution_recipe])
 
 # Throws
@@ -78,7 +78,7 @@ $(distribution_method_description[:update_distribution!])
 - $(distribution_arg_list[:distribution_recipe])
 - $(distribution_arg_list[:A]) 
 
-# Outputs
+# Returns
 - Modifies the `DistributionRecipe` in place and returns nothing.
 
 # Throws
@@ -106,7 +106,7 @@ $(distribution_method_description[:sample_distribution!])
 - $(distribution_arg_list[:x]) 
 - $(distribution_arg_list[:distribution_recipe])
 
-# Outputs
+# Returns
 - Modifies the `x` in place by sampling that follows the weights and replacement given by 
 'DistributionRecipe'.
 

--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -63,7 +63,7 @@ $(solver_method_description[:complete_solver])
 - $(solver_arg_list[:A]) 
 - $(solver_arg_list[:b]) 
 
-# Outputs
+# Returns
 - $(solver_output_list[:solver_recipe])
 
 # Throws
@@ -102,7 +102,7 @@ $(solver_method_description[:rsolve])
 - $(solver_arg_list[:A]) 
 - $(solver_arg_list[:b]) 
 
-# Outputs
+# Returns
 - Returns `nothing`. Updates the `SolverRecipe` and `x` in place.
 
 # Throws
@@ -138,7 +138,7 @@ $(solver_method_description[:rsolve])
 - $(solver_arg_list[:A]) 
 - $(solver_arg_list[:b]) 
 
-# Outputs
+# Returns
 - $(solver_output_list[:x])
 - $(solver_output_list[:solver_recipe])
 """

--- a/src/Solvers/Loggers.jl
+++ b/src/Solvers/Loggers.jl
@@ -49,13 +49,13 @@ logger_error_list = Dict{Symbol, String}(
 
 $(logger_method_description[:complete_logger])
 
-### Arguments
+# Arguments
 - $(logger_arg_list[:logger])
 
-### Returns 
+# Returns
 - $(logger_output_list[:logger_recipe])
 
-### Throws
+# Throws
 - $(logger_error_list[:complete_logger])
 """
 function complete_logger(logger::Logger)
@@ -69,15 +69,15 @@ end
 
 $(logger_method_description[:update_logger])
 
-### Arguments
+# Arguments
 - $(logger_arg_list[:logger_recipe])
-- $(logger_arg_list[:err]) 
-- $(logger_arg_list[:iteration]) 
+- $(logger_arg_list[:err])
+- $(logger_arg_list[:iteration])
 
-### Returns 
+# Returns
 - Performs an inplace update to the `LoggerRecipe` and returns nothing.
 
-### Throws
+# Throws
 - $(logger_error_list[:update_logger])
 """
 function update_logger!(logger::LoggerRecipe, err::Real, iteration::Int64)
@@ -92,13 +92,13 @@ end
 
 $(logger_method_description[:reset_logger])
 
-### Arguments
+# Arguments
 - $(logger_arg_list[:logger_recipe])
 
-### Returns 
+# Returns
 - Performs an inplace update to the `LoggerRecipe` and returns nothing.
 
-### Throws
+# Throws
 - $(logger_error_list[:reset_logger])
 """
 function reset_logger!(logger::LoggerRecipe)

--- a/src/Solvers/col_projection.jl
+++ b/src/Solvers/col_projection.jl
@@ -270,7 +270,7 @@ and
 # Arguments
 - `solver::ColumnProjectionRecipe`, the solver information required for performing the update.
 
-# Outputs
+# Returns
 - returns `nothing`
 """
 function colproj_update!(solver::ColumnProjectionRecipe)
@@ -303,7 +303,7 @@ and stores it in `solver.residual_vec`.
 # Arguments
 - `solver::ColumnProjectionRecipe`, the solver information required for performing the update.
 
-# Outputs
+# Returns
 - returns `nothing`
 """
 function colproj_update_block!(solver::ColumnProjectionRecipe)

--- a/src/Solvers/kaczmarz.jl
+++ b/src/Solvers/kaczmarz.jl
@@ -256,7 +256,7 @@ A function that performs the Kaczmarz update when the compression dimension is o
 # Arguments
 - `solver::KaczmarzRecipe`, the solver information required for performing the update.
 
-# Outputs
+# Returns
 - returns `nothing`
 """
 function kaczmarz_update!(solver::KaczmarzRecipe)
@@ -288,7 +288,7 @@ A function that performs the kaczmarz update when the compression dim is greater
 # Arguments
 - `solver::KaczmarzRecipe`, the solver information required for performing the update.
 
-# Outputs
+# Returns
 - returns `nothing`
 """
 function kaczmarz_update_block!(solver::KaczmarzRecipe)


### PR DESCRIPTION
Added Claude to the code base and used it to modify docstring files to be consistent.

## Description
This PR does the following:
- It adds initialization files for Claude into a `.claude/` folder.
- It leverages Claude to understand common docstring patterns in the code base and suggest changes to bring all code docstrings into the same pattern

In particular, 
- It shifts `#Outputs` --> `#Returns`
- It shifts `###` header indicators to `##`

## Motivation and Context
This PR is motivated by using agentic LLMs to help develop code, and to test their capabilities with a low-risk task.

## How has this been tested
Docs have been compiled. 

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [x] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [ ] Fix <!--- Non-breaking change which addresses an issue -->
- [ ] Performance <!--- A code change that improves performance -->
- [ ] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [x] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [ ] My code follows the code style of this project.
- [ ] I have updated all package dependencies (if any).
- [ ] I have included all relevant files to realize the functionality of the PR. 
- [ ] I have exported relevant functionality (if any).

**API Documentation**
- [ ] For every exported function (if any), I have included a detailed docstring.
- [x] I have checked the spelling and grammar of all docstring updates through an external tool.
- [x] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [ ] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [x] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [ ] I have checked the spelling and grammar of all manual updates through an external tool.
- [ ] Any code included in the docstring is tested using doc tests to ensure consistency.
- [ ] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [ ] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [ ] All new and existing tests passed.
- [ ] I have achieved sufficient code coverage.

