### PR TITLE
Consistency of Distributions.jl Docstrings

### DIFF
--- a/.github/ISSUE_TEMPLATE/cleanup.md
+++ b/.github/ISSUE_TEMPLATE/cleanup.md
@@ -1,0 +1,20 @@
+---
+name: Cleanup
+about: Report a style, naming, or code quality inconsistency to be standardised
+title: ''
+labels: documentation, stylistic change
+assignees: dmaldona, npritch928, vp314
+
+---
+
+**What needs to be standardised**
+A clear description of the convention or style that is inconsistent.
+
+**Where it applies**
+List of files, structs, or functions affected.
+
+**Correct pattern**
+A concrete example of what the correct style looks like.
+
+**Additional context**
+Any relevant references or prior work.

--- a/src/Compressors/Distributions.jl
+++ b/src/Compressors/Distributions.jl
@@ -18,7 +18,7 @@ distribution_arg_list = Dict{Symbol,String}(
     :distribution => "`distribution::Distribution`, a user-specified distribution function for sampling.",
     :distribution_recipe => "`distribution::DistributionRecipe`, a fully initialized realization of distribution.",
     :A => "`A::AbstractMatrix`, a coefficient matrix.",
-    :x => "`x::AbstractVector`, an abstract vector to store the sampled indices.",
+    :indices => "`indices::AbstractVector`, an abstract vector to store the sampled indices.",
 )
 
 distribution_output_list = Dict{Symbol,String}(
@@ -30,7 +30,7 @@ distribution_method_description = Dict{Symbol,String}(
     arguments.",
     :update_distribution! => "A function that updates the `DistributionRecipe` in place given 
     arguments.",
-    :sample_distribution! => "A function that in place updates the `x` by given `DistributionRecipe` info.",
+    :sample_distribution! => "A function that in place updates `indices` by given `DistributionRecipe` info.",
 )
 
 distribution_error_list = Dict{Symbol,String}(
@@ -50,7 +50,7 @@ $(distribution_method_description[:complete_distribution])
 - $(distribution_arg_list[:distribution])
 - $(distribution_arg_list[:A]) 
 
-# Outputs
+# Returns
 - $(distribution_output_list[:distribution_recipe])
 
 # Throws
@@ -78,7 +78,7 @@ $(distribution_method_description[:update_distribution!])
 - $(distribution_arg_list[:distribution_recipe])
 - $(distribution_arg_list[:A]) 
 
-# Outputs
+# Returns
 - Modifies the `DistributionRecipe` in place and returns nothing.
 
 # Throws
@@ -98,24 +98,24 @@ function update_distribution!(distribution::DistributionRecipe, x::AbstractVecto
 end
 
 """
-    sample_distribution!(x::AbstractVector, distribution::DistributionRecipe)
+    sample_distribution!(indices::AbstractVector, distribution::DistributionRecipe)
 
 $(distribution_method_description[:sample_distribution!])
 
 # Arguments
-- $(distribution_arg_list[:x]) 
+- $(distribution_arg_list[:indices])
 - $(distribution_arg_list[:distribution_recipe])
 
-# Outputs
-- Modifies the `x` in place by sampling that follows the weights and replacement given by 
-'DistributionRecipe'.
+# Returns
+- Modifies `indices` in place by sampling that follows the weights and replacement given by
+`DistributionRecipe`.
 
 # Throws
 - $(distribution_error_list[:sample_distribution!])
 """
-function sample_distribution!(x::AbstractVector, distribution::DistributionRecipe)
+function sample_distribution!(indices::AbstractVector, distribution::DistributionRecipe)
     return throw(ArgumentError("No `sample_distribution!` method defined for a distribution of type \
-    $(typeof(distribution)) and $(typeof(x))."))
+    $(typeof(distribution)) and $(typeof(indices))."))
 end
 
 ###########################################

--- a/src/Compressors/Distributions/strohmer_vershynin.jl
+++ b/src/Compressors/Distributions/strohmer_vershynin.jl
@@ -58,6 +58,21 @@ mutable struct L2NormRecipe <: DistributionRecipe
     weights::ProbabilityWeights
 end
 
+"""
+    complete_distribution(distribution::L2Norm, A::AbstractMatrix)
+
+Creates an `L2NormRecipe` for the given distribution and matrix.
+
+# Arguments
+- `distribution::L2Norm`: The L2Norm distribution specification.
+- `A::AbstractMatrix`: Coefficient matrix.
+
+# Returns
+- `L2NormRecipe`: A recipe containing all necessary allocations.
+
+# Throws
+- `ArgumentError` if cardinality is `Undef()`.
+"""
 function complete_distribution(distribution::L2Norm, A::AbstractMatrix)
     cardinality = distribution.cardinality
     if cardinality == Left()
@@ -82,6 +97,21 @@ function complete_distribution(distribution::L2Norm, A::AbstractMatrix)
     return L2NormRecipe(cardinality, distribution.replace, state_space, weights)
 end
 
+"""
+    update_distribution!(ingredients::L2NormRecipe, A::AbstractMatrix)
+
+Updates the L2Norm distribution recipe with the current matrix.
+
+# Arguments
+- `ingredients::L2NormRecipe`: The recipe to update.
+- `A::AbstractMatrix`: Coefficient matrix.
+
+# Returns
+- Modifies `ingredients` in place and returns nothing.
+
+# Throws
+- `ArgumentError` if cardinality is `Undef()`.
+"""
 function update_distribution!(ingredients::L2NormRecipe, A::AbstractMatrix)
     if ingredients.cardinality == Left()
         n_rows = size(A, 1)
@@ -105,7 +135,19 @@ function update_distribution!(ingredients::L2NormRecipe, A::AbstractMatrix)
     return nothing
 end
 
-function sample_distribution!(x::AbstractVector, distribution::L2NormRecipe)
-    wsample!(distribution.state_space, distribution.weights, x, ordered = true, replace = distribution.replace)
+"""
+    sample_distribution!(indices::AbstractVector, distribution::L2NormRecipe)
+
+Samples indices according to the L2Norm distribution.
+
+# Arguments
+- `indices::AbstractVector`: Output vector to store selected indices.
+- `distribution::L2NormRecipe`: The recipe containing sampling parameters.
+
+# Returns
+- Modifies `indices` in place with the selected indices and returns nothing.
+"""
+function sample_distribution!(indices::AbstractVector, distribution::L2NormRecipe)
+    wsample!(distribution.state_space, distribution.weights, indices, ordered = true, replace = distribution.replace)
     return nothing
 end

--- a/src/Compressors/Distributions/uniform.jl
+++ b/src/Compressors/Distributions/uniform.jl
@@ -53,6 +53,21 @@ mutable struct UniformRecipe <: DistributionRecipe
     weights::ProbabilityWeights
 end
 
+"""
+    complete_distribution(distribution::Uniform, A::AbstractMatrix)
+
+Creates a `UniformRecipe` for the given uniform distribution and matrix.
+
+# Arguments
+- `distribution::Uniform`: The uniform distribution specification.
+- `A::AbstractMatrix`: Coefficient matrix.
+
+# Returns
+- `UniformRecipe`: A recipe containing all necessary allocations.
+
+# Throws
+- `ArgumentError` if cardinality is `Undef()`.
+"""
 function complete_distribution(distribution::Uniform, A::AbstractMatrix)
     cardinality = distribution.cardinality
     if cardinality == Left()
@@ -71,6 +86,21 @@ function complete_distribution(distribution::Uniform, A::AbstractMatrix)
     return UniformRecipe(cardinality, distribution.replace, state_space, weights)
 end
 
+"""
+    update_distribution!(ingredients::UniformRecipe, A::AbstractMatrix)
+
+Updates the uniform distribution recipe with the current matrix.
+
+# Arguments
+- `ingredients::UniformRecipe`: The recipe to update.
+- `A::AbstractMatrix`: Coefficient matrix.
+
+# Returns
+- Modifies `ingredients` in place and returns nothing.
+
+# Throws
+- `ArgumentError` if cardinality is `Undef()`.
+"""
 function update_distribution!(ingredients::UniformRecipe, A::AbstractMatrix)
     if ingredients.cardinality == Left()
         n_rows = size(A, 1)
@@ -88,7 +118,19 @@ function update_distribution!(ingredients::UniformRecipe, A::AbstractMatrix)
     return nothing
 end
 
-function sample_distribution!(x::AbstractVector, distribution::UniformRecipe)
-    wsample!(distribution.state_space, distribution.weights, x, ordered = true, replace = distribution.replace)
+"""
+    sample_distribution!(indices::AbstractVector, distribution::UniformRecipe)
+
+Samples indices according to the uniform distribution.
+
+# Arguments
+- `indices::AbstractVector`: Output vector to store selected indices.
+- `distribution::UniformRecipe`: The recipe containing sampling parameters.
+
+# Returns
+- Modifies `indices` in place with the selected indices and returns nothing.
+"""
+function sample_distribution!(indices::AbstractVector, distribution::UniformRecipe)
+    wsample!(distribution.state_space, distribution.weights, indices, ordered = true, replace = distribution.replace)
     return nothing
 end


### PR DESCRIPTION
## Description
This PR improves the documentation consistency of `src/Compressors/Distributions.jl` and its concrete implementations by adding docstrings to `Uniform` and `L2Norm` interface functions and renaming `x` to `indices` in `sample_distribution!`.

Fixes #166, and #169

## Motivation and Context
`Uniform` and `L2Norm` were missing docstrings for their concrete implementations of `complete_distribution`, `update_distribution!`, and `sample_distribution!`. Since Julia shows the most specific method's docstring, users got no documentation when looking up these functions with a `UniformRecipe` or `L2NormRecipe`.

The parameter name `x` in `sample_distribution!` was ambiguous since `x` conventionally refers to the solution iterate in `Ax = b`. Renamed to `indices` throughout the abstract interface and both concrete implementations.

Also fixes `# Outputs` → `# Returns` in `Distributions.jl` to match the convention used across the rest of the codebase.

## How has this been tested
No behaviour changes, documentation, and naming only. Existing tests were run and passed. Docs were built locally and reviewed.

## Types of changes
- [ ] CI
- [x] Docs
- [ ] Feature
- [ ] Fix
- [ ] Performance
- [ ] Refactor
- [x] Style
- [ ] Test
- [ ] Other

## Checklists:

**Code and Comments**
- [x] My code follows the code style of this project.
- [x] I have updated all package dependencies (if any).
- [x] I have included all relevant files to realize the functionality of the PR.
- [x] I have exported relevant functionality (if any).

**API Documentation**
- [x] For every exported function (if any), I have included a detailed docstring.
- [x] I have checked the spelling and grammar of all docstring updates through an external tool.
- [x] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [x] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [x] I have compiled the docs locally and read through all docstring updates to check for errors.

**Manual Documentation**
- [ ] I have checked the spelling and grammar of all manual updates through an external tool.
- [ ] Any code included in the docstring is tested using doc tests to ensure consistency.
- [ ] I have compiled the docs locally and read through all manual updates to check for errors.

**Testing**
- [ ] I have added unit tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have achieved sufficient code coverage.
