### PR TITLE
Enforce keyword constructor type annotations 

### DIFF
--- a/src/Approximators/RangeApproximators/rangefinder.jl
+++ b/src/Approximators/RangeApproximators/rangefinder.jl
@@ -83,9 +83,9 @@ mutable struct RangeFinder <: RangeApproximator
 end
 
 RangeFinder(;
-    compressor = SparseSign(cardinality = Right()), 
-    orthogonalize = false, 
-    power_its = 0
+    compressor::Compressor = SparseSign(cardinality = Right()),
+    orthogonalize::Bool = false,
+    power_its::Int64 = 0
 ) = RangeFinder(compressor, power_its, orthogonalize)
 
 """

--- a/src/Approximators/Selectors/lupp.jl
+++ b/src/Approximators/Selectors/lupp.jl
@@ -27,7 +27,7 @@ mutable struct LUPP <: Selector
     compressor::Compressor
 end
  
-function LUPP(;compressor = Identity()) 
+function LUPP(; compressor::Compressor = Identity())
     return LUPP(compressor)
 end
 

--- a/src/Approximators/Selectors/qrcp.jl
+++ b/src/Approximators/Selectors/qrcp.jl
@@ -22,7 +22,7 @@ mutable struct QRCP <: Selector
     compressor::Compressor
 end
 
-function QRCP(;compressor = Identity()) 
+function QRCP(; compressor::Compressor = Identity())
     QRCP(compressor)
 end
 

--- a/src/Compressors/Distributions/strohmer_vershynin.jl
+++ b/src/Compressors/Distributions/strohmer_vershynin.jl
@@ -32,7 +32,7 @@ mutable struct L2Norm <: Distribution
     replace::Bool
 end
 
-function L2Norm(; cardinality = Undef(), replace = false)
+function L2Norm(; cardinality::Cardinality = Undef(), replace::Bool = false)
     return L2Norm(cardinality, replace)
 end
 

--- a/src/Compressors/Distributions/uniform.jl
+++ b/src/Compressors/Distributions/uniform.jl
@@ -29,7 +29,7 @@ mutable struct Uniform <: Distribution
     replace::Bool
 end
 
-function Uniform(; cardinality = Undef(), replace = false)
+function Uniform(; cardinality::Cardinality = Undef(), replace::Bool = false)
     return Uniform(cardinality, replace)
 end
 

--- a/src/Compressors/fjlt.jl
+++ b/src/Compressors/fjlt.jl
@@ -88,7 +88,7 @@ struct FJLT <: Compressor
 end
 
 function FJLT(;
-    cardinality=Left(),
+    cardinality::Cardinality=Left(),
     compression_dim::Int64=2,
     block_size::Int64=10,
     sparsity::Float64=0.0,

--- a/src/Compressors/identity.jl
+++ b/src/Compressors/identity.jl
@@ -22,7 +22,7 @@ mutable struct Identity <: Compressor
     cardinality::Cardinality 
 end
 
-function Identity(;cardinality = Left())
+function Identity(; cardinality::Cardinality = Left())
     Identity(cardinality)
 end
 

--- a/src/Compressors/sparse_sign.jl
+++ b/src/Compressors/sparse_sign.jl
@@ -88,7 +88,7 @@ mutable struct SparseSign <: Compressor
 end
 
 function SparseSign(;
-    cardinality=Left(),
+    cardinality::Cardinality=Left(),
     compression_dim::Int64=2,
     nnz::Int64=min(8, compression_dim),
     type::Type{N}=Float64,

--- a/src/Compressors/srht.jl
+++ b/src/Compressors/srht.jl
@@ -79,7 +79,7 @@ struct SRHT <: Compressor
 end
 
 function SRHT(;
-    cardinality = Left(),
+    cardinality::Cardinality = Left(),
     compression_dim::Int64=2,
     block_size::Int64=10,
     type::Type{N}=Float64

--- a/src/Solvers/Loggers/basic_logger.jl
+++ b/src/Solvers/Loggers/basic_logger.jl
@@ -32,10 +32,10 @@ struct BasicLogger <: Logger
 end
 
 BasicLogger(;
-            max_it = 0, 
-            collection_rate = 1, 
-            threshold = 0.0,
-            stopping_criterion = threshold_stop 
+            max_it::Int64 = 0,
+            collection_rate::Int64 = 1,
+            threshold::Union{Float64, Tuple} = 0.0,
+            stopping_criterion::Function = threshold_stop
            ) = BasicLogger(max_it, collection_rate, threshold, stopping_criterion)
 
 """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be sure to request review from @vp314, @dmaldona, and/or @nathanielpritchard -->

## Description
<!--- Describe your changes in detail and include references -->
Adds explicit type annotations to keyword arguments in constructors that were missing them across compressors, distributions, selectors, range approximators, and logger components.

Fixes #172 <!--- If there is an issue being resolved, please indicate it here. Otherwise delete this line. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #172 requested consistency in keyword constructor signatures, since several constructors had missing keyword type annotations, while others already followed this pattern.

## How has this been tested
<!--- Please describe the manual steps a reviewer can take to verify your changes. -->
<!--- This is critical for ensuring the change works as expected. -->
Testing was done with julia --project -e 'using Pkg; Pkg.test()', and the full suite passed. After the final SparseSign constructor fix, its focused tests were also re-run and passed.

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [ ] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [ ] Fix <!--- Non-breaking change which addresses an issue -->
- [ ] Performance <!--- A code change that improves performance -->
- [x] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [ ] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [x] My code follows the code style of this project.
- [x] I have updated all package dependencies (if any).
- [x] I have included all relevant files to realize the functionality of the PR. 
- [x] I have exported relevant functionality (if any).

**API Documentation**
- [ ] For every exported function (if any), I have included a detailed docstring.
- [ ] I have checked the spelling and grammar of all docstring updates through an external tool.
- [ ] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [ ] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [ ] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [ ] I have checked the spelling and grammar of all manual updates through an external tool.
- [ ] Any code included in the docstring is tested using doc tests to ensure consistency.
- [ ] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [ ] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [x] All new and existing tests passed.
- [x] I have achieved sufficient code coverage.

