### PR TITLE
Filled Missing RangeFinder Coverage

### DIFF
--- a/test/Approximators/RangeApproximator/rangefinder.jl
+++ b/test/Approximators/RangeApproximator/rangefinder.jl
@@ -66,6 +66,14 @@ end
             @test rf.power_its == 2
             @test rf.orthogonalize == false
         end
+
+        # Test default constructor
+        let 
+            rf = RangeFinder()
+            @test typeof(rf.compressor) <: SparseSign
+            @test rf.orthogonalize == false
+            @test rf.power_its == 0
+        end
     
     end
 
@@ -300,7 +308,49 @@ end
             mul!(b', v', approx_rec, 2.0, 1.0)
             @test b ≈ (bc' + 2.0  * v' * approx_rec.range)'
         end
+        
+        # Perform tests with adjoint multiplications
+        # first from the left
+        let approx_rec = approx_rec, 
+            A = A, 
+            C = C,
+            Cc = deepcopy(C) 
 
+            mul!(C, approx_rec', A, 2.0, 1.0)
+            @test C ≈ Cc + 2.0 * approx_rec.range' * A
+        end
+
+        # test multiplication from the right
+        let approx_rec = approx_rec, 
+            A = A, 
+            C = C,
+            Cc = deepcopy(C) 
+
+            mul!(C, A, approx_rec', 2.0, 1.0)
+            @test C ≈ Cc + 2.0 * A * approx_rec.range'
+        end
+
+        # Test the vector multiplication
+        # from the right
+        let approx_rec = approx_rec, 
+            v = v, 
+            b = b,
+            bc = deepcopy(b) 
+
+            mul!(b, approx_rec', v, 2.0, 1.0)
+            @test b ≈ bc + 2.0 * approx_rec.range' * v
+        end
+
+        # Test the vector multiplication
+        # from the left 
+        let approx_rec = approx_rec, 
+            v = v, 
+            b = b,
+            bc = deepcopy(b) 
+
+            mul!(b', v', approx_rec', 2.0, 1.0)
+            @test b' ≈ (bc' + 2.0  * v' * approx_rec.range')
+        end
     end
 
 


### PR DESCRIPTION


## Description
Adds tests to improve the coverage of the RangeFinder, specifically:
1. Added a test for the default constructor
2. Added tests for all the adjoints that were missing

## Motivation and Context
Previous version did not test the default constructor nor the adjoint versions of the RangeFinder. This led to less than 100% coverage. This commit adds the missing tests.

## How has this been tested
I have run the tests on my laptop.

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [ ] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [x] Fix <!--- Non-breaking change which addresses an issue -->
- [ ] Performance <!--- A code change that improves performance -->
- [ ] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [ ] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [ ] My code follows the code style of this project.
- [ ] I have updated all package dependencies (if any).
- [ ] I have included all relevant files to realize the functionality of the PR. 
- [ ] I have exported relevant functionality (if any).

**API Documentation**
- [ ] For every exported function (if any), I have included a detailed docstring.
- [ ] I have checked the spelling and grammar of all docstring updates through an external tool.
- [ ] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [ ] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [ ] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [ ] I have checked the spelling and grammar of all manual updates through an external tool.
- [ ] Any code included in the docstring is tested using doc tests to ensure consistency.
- [ ] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [x] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [x] All new and existing tests passed.
- [x] I have achieved sufficient code coverage.

