### PR TITLE
Resolved type uncertainty in Hadamard based muls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RandLinearAlgebra"
 uuid = "da1d211a-c3bc-43b2-b5d0-ce83f16a0f3a"
-authors = ["Christian Varner <cvarner@wisc.edu>", "Daniel Adrian Maldonado <maldonadod@anl.gov>", "Nathaniel Pritchard <Nathaniel.Pritchard@maths.ox.ac.uk>", "TongTong Jin <ttjin@uchicago.edu>", "Tunan Wang <tunan.wang@wisc.edu>", "Vivak Patel <vivak.patel@wisc.edu>"]
 version = "0.2.4"
+authors = ["Christian Varner <cvarner@wisc.edu>", "Daniel Adrian Maldonado <maldonadod@anl.gov>", "Nathaniel Pritchard <Nathaniel.Pritchard@maths.ox.ac.uk>", "TongTong Jin <ttjin@uchicago.edu>", "Tunan Wang <tunan.wang@wisc.edu>", "Vivak Patel <vivak.patel@wisc.edu>"]
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Compressors/fjlt.jl
+++ b/src/Compressors/fjlt.jl
@@ -288,8 +288,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         # Apply the operator to the matrix
@@ -309,8 +309,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
         
         # Perform accesses only up to the entries
@@ -355,8 +355,8 @@ function mul!(
         # Apply signs and fwht to the padding matrix along the columns of the padding matrix
         # this is equivalent to applying the hadamard transform to the rows of AS.op as desired
         for i in 1:b_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, scaling = S.scale) 
         end
 
         # Because apply sign transform after hadmard is different than the reverse can't
@@ -380,8 +380,8 @@ function mul!(
         mul!(pv', Av, S.op, alpha, zero(type))
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, scaling = S.scale) 
         end
         
         # Because apply sign transform after hadmard is different than the reverse can't
@@ -429,8 +429,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         # Apply the operator to the matrix
@@ -450,8 +450,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         pv = view(S.padding, 1:last_block_size, :)
@@ -493,8 +493,8 @@ function mul!(
         mul!(pv', S.op, Av, alpha, zero(type))
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, scaling = S.scale) 
         end
 
         # Flip the signs
@@ -517,8 +517,8 @@ function mul!(
         mul!(pv', S.op, Av,  alpha, zero(type))
         # Apply and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, scaling = S.scale)
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, scaling = S.scale)
         end
         
         # Apply signs to the padding matrix

--- a/src/Compressors/helpers/fwht.jl
+++ b/src/Compressors/helpers/fwht.jl
@@ -27,6 +27,7 @@ function fwht!(x::AbstractVector, signs::BitVector; scaling = 1)
     elseif rem(log(2, ln), 1) != 0 
         throw(DimensionMismatch("Size of vector must be power of 2."))
     end
+
     # size of separation between indices
     h = 1 
     #  set increment to be twice of h
@@ -37,7 +38,7 @@ function fwht!(x::AbstractVector, signs::BitVector; scaling = 1)
     # In 1st pass scale and flip signs of entries, this does not need to be done 
     # in any other passes over the vector. To avoid unnecessary condition checking 
     # this portion of the loop has been separated out from the others.
-    for i in 1:inc:ln
+    @inbounds for i in 1:inc:ln
         # Signs is vector of Bools
         z = x[i] * (signs[i] ? scaling : -scaling) 
         y = x[i+h] * (signs[i+h] ? scaling : -scaling)
@@ -46,7 +47,7 @@ function fwht!(x::AbstractVector, signs::BitVector; scaling = 1)
         
     end
 
-    for k = 1:total_its
+    @inbounds for k = 1:total_its
         # Double distance between next combintation
         h <<= 1
         # spacing between operations
@@ -85,7 +86,7 @@ function fwht!(x::AbstractVector; scaling = 1)
     # In 1st pass scale and flip signs of entries, this does not need to be done 
     # in any other passes over the vector. To avoid unnecessary condition checking 
     # this portion of the loop has been separated out fron the others.
-    for i in 1:inc:ln
+    @inbounds for i in 1:inc:ln
         # Signs is vector of Bools
         z = x[i] * scaling 
         y = x[i+h] * scaling
@@ -94,7 +95,7 @@ function fwht!(x::AbstractVector; scaling = 1)
         
     end
 
-    for k = 1:total_its
+    @inbounds for k = 1:total_its
         # Double distance between next combintation
         h <<= 1
         # spacing between operations

--- a/src/Compressors/srht.jl
+++ b/src/Compressors/srht.jl
@@ -251,8 +251,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         # Apply the operator to the matrix
@@ -272,8 +272,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
         
         # Perform accesses only up to the entries
@@ -320,8 +320,8 @@ function mul!(
         # this is equivalent to applying the hadamard transform to the rows of AS.op 
         # as desired
         for i in 1:b_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, scaling = S.scale) 
         end
 
         # Because apply sign transform after hadmard is different than the reverse can't
@@ -346,8 +346,8 @@ function mul!(
         pv' .= alpha .* Av 
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, :, i)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, :, i)
+            fwht!(pv1, scaling = S.scale) 
         end
         
         # Because apply sign transform after hadamard is different than the reverse can't
@@ -395,8 +395,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         # Apply the operator to the matrix
@@ -416,8 +416,8 @@ function mul!(
         copyto!(pv, Av)
         # Apply signs and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, S.signs, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, S.signs, scaling = S.scale) 
         end
 
         pv = view(S.padding, 1:last_block_size, :)
@@ -461,8 +461,8 @@ function mul!(
         pv' .= alpha .* Av 
         # Apply signs and fwht to the padding matrix
         for i in 1:b_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, scaling = S.scale) 
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, scaling = S.scale) 
         end
 
         # Flip the signs
@@ -486,8 +486,8 @@ function mul!(
         pv' .= alpha .* Av 
         # Apply and fwht to the padding matrix
         for i in 1:last_block_size
-            pv = view(S.padding, i, :)
-            fwht!(pv, scaling = S.scale)
+            pv1 = view(S.padding, i, :)
+            fwht!(pv1, scaling = S.scale)
         end
         
         # Apply signs to the padding matrix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be sure to request review from @vp314, @dmaldona, and/or @nathanielpritchard -->

## Description
In the `FJLT` and `SRHT` muls there was a variable, `pv`, used as view for a matrix and vector, which introduced type uncertainty.  I have changed the vector view to `pv1` to resolve this uncertainty. Also profiling showed that bounds checking was hampering the performance of `fwht!`, so `@inbounds` was added to the loops in these functions.

## Motivation and Context
SRHT was scaling on the order n^2 further investigation revealed issues with type uncertainty and bounds checking. This has appeared to improve the scaling to something less than n^2.

## How has this been tested
I have run the tests previously written for these multiplications.

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [ ] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [ ] Fix <!--- Non-breaking change which addresses an issue -->
- [x] Performance <!--- A code change that improves performance -->
- [ ] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [ ] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [x] My code follows the code style of this project.
- [x] I have updated all package dependencies (if any).
- [x] I have included all relevant files to realize the functionality of the PR. 
- [x] I have exported relevant functionality (if any).

**API Documentation**
- [x] For every exported function (if any), I have included a detailed docstring.
- [x] I have checked the spelling and grammar of all docstring updates through an external tool.
- [x] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [x] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [x] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [x] I have checked the spelling and grammar of all manual updates through an external tool.
- [x] Any code included in the docstring is tested using doc tests to ensure consistency.
- [x] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [x] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [x] All new and existing tests passed.
- [x] I have achieved sufficient code coverage.

