### PR TITLE
scaling was wrong updated and added inbounds

### DIFF
--- a/src/Compressors/helpers/fwht.jl
+++ b/src/Compressors/helpers/fwht.jl
@@ -52,8 +52,8 @@ function fwht!(x::AbstractVector, signs::BitVector; scaling = 1)
         h <<= 1
         # spacing between operations
         inc = h << 1
-        for i in 1:inc:ln
-            for j in i:(i+h-1)
+        @inbounds for i in 1:inc:ln
+            @inbounds for j in i:(i+h-1)
                 # Perform fwht 
                 z = x[j]  
                 y = x[j+h]
@@ -100,8 +100,8 @@ function fwht!(x::AbstractVector; scaling = 1)
         h <<= 1
         # spacing between operations
         inc = h << 1
-        for i in 1:inc:ln
-            for j in i:(i+h-1)
+        @inbounds for i in 1:inc:ln
+            @inbounds for j in i:(i+h-1)
                 # Perform fwht 
                 z = x[j]  
                 y = x[j+h]

--- a/src/Compressors/srht.jl
+++ b/src/Compressors/srht.jl
@@ -149,7 +149,7 @@ function SRHTRecipe(
     padded_matrix = zeros(type, padded_size, block_size)
     signs = bitrand(padded_size)
     idx = sample(1:padded_size, compression_dim, replace = false)
-    scaling = type(sqrt(compression_dim) / sqrt(padded_size))
+    scaling = type(1 / sqrt(compression_dim))
     return SRHTRecipe{typeof(cardinality), typeof(padded_matrix)}(
         cardinality,
         n_rows,
@@ -178,7 +178,7 @@ function SRHTRecipe(
     padded_matrix = zeros(type, block_size, padded_size)
     signs = bitrand(padded_size)
     idx = sample(1:padded_size, compression_dim, replace = false)
-    scaling = type(sqrt(compression_dim) / sqrt(padded_size))
+    scaling = type(1 / sqrt(compression_dim))
     return SRHTRecipe{typeof(cardinality), typeof(padded_matrix)}(
         cardinality,
         n_rows,

--- a/test/Compressors/srht.jl
+++ b/test/Compressors/srht.jl
@@ -80,7 +80,7 @@ Random.seed!(1223)
             @test recipe.n_rows == comp_dim
             @test recipe.n_cols == n_rows
             @test recipe.scale == type(
-                sqrt(comp_dim) / sqrt(padded_dim)
+                1 / sqrt(comp_dim)
             )
             @test typeof(recipe.op) == Vector{Int64} 
             @test typeof(recipe.signs) == BitVector
@@ -107,7 +107,7 @@ Random.seed!(1223)
             @test recipe.n_rows == comp_dim
             @test recipe.n_cols == n_rows
             @test recipe.scale == type(
-                sqrt(comp_dim) / sqrt(padded_dim)
+                1 / sqrt(comp_dim)
             )
             @test typeof(recipe.op) == Vector{Int64} 
             @test typeof(recipe.signs) == BitVector
@@ -133,7 +133,7 @@ Random.seed!(1223)
             @test recipe.n_rows == n_cols
             @test recipe.n_cols == comp_dim
             @test recipe.scale == type(
-                sqrt(comp_dim) / sqrt(padded_dim)
+                1 / sqrt(comp_dim)
             )
             @test typeof(recipe.op) == Vector{Int64} 
             @test typeof(recipe.signs) == BitVector
@@ -160,7 +160,7 @@ Random.seed!(1223)
             @test recipe.n_rows == n_cols 
             @test recipe.n_cols == comp_dim
             @test recipe.scale == type(
-                sqrt(comp_dim) / sqrt(padded_dim)
+                1 / sqrt(comp_dim)
             )
             @test typeof(recipe.op) == Vector{Int64} 
             @test typeof(recipe.signs) == BitVector
@@ -186,7 +186,7 @@ Random.seed!(1223)
             @test compressor_recipe.cardinality == card
             @test compressor_recipe.n_rows == c_dim
             @test compressor_recipe.n_cols == n_rows 
-            @test compressor_recipe.scale == type(sqrt(4) / sqrt(16))
+            @test compressor_recipe.scale == type(1 / sqrt(4))
             @test typeof(compressor_recipe.op) <: Vector{Int64} 
             @test typeof(compressor_recipe.signs) == BitVector
             @test typeof(compressor_recipe.padding) == Matrix{type}
@@ -207,7 +207,7 @@ Random.seed!(1223)
             @test compressor_recipe.cardinality == card
             @test compressor_recipe.n_rows == n_cols 
             @test compressor_recipe.n_cols == c_dim
-            @test compressor_recipe.scale == type(sqrt(4) / sqrt(16))
+            @test compressor_recipe.scale == type(1 / sqrt(4))
             @test typeof(compressor_recipe.op) <: Vector{Int64} 
             @test typeof(compressor_recipe.signs) == BitVector
             @test typeof(compressor_recipe.padding) == Matrix{type}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be sure to request review from @vp314, @dmaldona, and/or @nathanielpritchard -->

## Description
I profiled SRHT and realized that it was still spending a lot of time on inbounds. I have added more inbounds to the fwht function. Additionally, I realized that the scaling we currently used was giving bad estimates. I updated to 1/sqrt(compression_dim) as it should be.

## Motivation and Context
The norm of the multiplied compressor and matrix and the original matrix should be close to one another. This was not happening. I have changed this so that it occurs.

## How has this been tested
I have used run test.

## Types of changes
<!--- The types are adapted from https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] CI <!--- Changes to the continuous integration configuration -->
- [ ] Docs <!--- Documentation only changes -->
- [ ] Feature <!--- Non-breaking changes that adds a new feature -->
- [ ] Fix <!--- Non-breaking change which addresses an issue -->
- [x] Performance <!--- A code change that improves performance -->
- [ ] Refactor <!--- Non-breaking change that neither fixes a bug nor adds a feature -->
- [ ] Style <!--- A change that corrects the style of the code presentation -->
- [ ] Test <!--- Adding missing tests or correcting existing tests -->
- [ ] Other (**use sparingly**): <!--- Use this sparingly. Please describe the type of change. -->

## Checklists:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

**Code and Comments**
If this PR includes modification to the code base, please select all that apply.
- [x] My code follows the code style of this project.
- [x] I have updated all package dependencies (if any).
- [x] I have included all relevant files to realize the functionality of the PR. 
- [x] I have exported relevant functionality (if any).

**API Documentation**
- [x] For every exported function (if any), I have included a detailed docstring.
- [x] I have checked the spelling and grammar of all docstring updates through an external tool.
- [x] I have checked that the docstring's function signature is correctly formatted and has all arguments.
- [x] I have checked that the docstring's list of arguments, fields, or return values match the function.
- [x] I have compiled the docs locally and read through all docstring updates to check for errors. 

**Manual Documentation**
- [x] I have checked the spelling and grammar of all manual updates through an external tool.
- [x] Any code included in the docstring is tested using doc tests to ensure consistency.
- [x] I have compiled the docs locally and read through all manual updates to check for errors. 

**Testing**
- [x] I have added unit tests to cover my changes. (For Macros, be sure to check
  [@code_lowered](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_lowered) and
  [@code_typed](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.@code_typed))
- [ ] All new and existing tests passed.
- [x] I have achieved sufficient code coverage.

